### PR TITLE
Follow the jquery.ajax spect with regards to the success and error callback and their return values

### DIFF
--- a/lib/najax.js
+++ b/lib/najax.js
@@ -146,6 +146,16 @@ function request(options, a, b) {
 		abort: notImplemented('abort')
 	};
 
+	function errorHandler(e) {
+		// Set data for the fake xhr object
+		jqXHR.responseText = e.stack;
+
+		if (_.isFunction(o.error)) {
+			o.error(jqXHR, 'error', e);
+		}
+		// jqXHR, statusText, error
+		dfd.reject(jqXHR, 'error', e);
+	}
 
 	var req = (ssl ? https : http).request(options, function(res) {
     // Allow getting Response Headers from the XMLHTTPRequest object
@@ -158,8 +168,11 @@ function request(options, a, b) {
 		res.on('end', function() {
 			if (o.dataType === 'json') {
 				//replace control characters
-				try { data = JSON.parse(data.replace(/[\cA-\cZ]/gi,'')); }
-				catch(e){ return !o.error||o.error(e); }
+				try {
+					data = JSON.parse(data.replace(/[\cA-\cZ]/gi,''));
+				} catch(e) {
+					return errorHandler(e);
+				}
 			}
 
 			// Determine if successful
@@ -190,17 +203,7 @@ function request(options, a, b) {
 		});
 	});
 //ERROR
-	req.on('error', function(e) {
-		// Set data for the fake xhr object
-		jqXHR.status = res.statusCode;
-		jqXHR.responseText = e.stack;
-
-		if (_.isFunction(o.error)) {
-			o.error(jqXHR, 'error', e);
-		}
-		// jqXHR, statusText, error
-		dfd.reject(jqXHR, 'error', e);
-	});
+	req.on('error', errorHandler);
 
 //SEND DATA
 	if (o.type !== 'GET' && o.data) {

--- a/lib/najax.js
+++ b/lib/najax.js
@@ -163,10 +163,10 @@ function request(options, a, b) {
 			var isSuccess = res.statusCode >= 200 && res.statusCode < 300 || res.statusCode === 304;
 			// Set readyState
 			jqXHR.readyState = res.statusCode > 0 ? 4 : 0;
+			jqXHR.status = res.statusCode;
 
 			if (isSuccess) {
 				// Set data for the fake xhr object
-				jqXHR.status = res.statusCode;
 				jqXHR.statusText = 'success';
 
 				if (_.isFunction(o.success)) {

--- a/lib/najax.js
+++ b/lib/najax.js
@@ -159,6 +159,7 @@ function request(options, a, b) {
 			}
 
 			// Determine if successful
+			// (per https://github.com/jquery/jquery/blob/master/src/ajax.js#L679)
 			var isSuccess = res.statusCode >= 200 && res.statusCode < 300 || res.statusCode === 304;
 			// Set readyState
 			jqXHR.readyState = res.statusCode > 0 ? 4 : 0;

--- a/lib/najax.js
+++ b/lib/najax.js
@@ -92,14 +92,14 @@ function request(options, a, b) {
 		rejectUnauthorized: o.rejectUnauthorized
 	};
 
-		/* set data content type */
-		if(o.type!=='GET' && o.data){
-			o.data = o.data+'\n';
-			options.headers = {
-				'Content-Type': o.contentType+';charset=utf-8',
-				'Content-Length': o.data ? Buffer.byteLength(o.data) : 0
-			};
-		}
+	/* set data content type */
+	if(o.type!=='GET' && o.data){
+		o.data = o.data+'\n';
+		options.headers = {
+			'Content-Type': o.contentType+';charset=utf-8',
+			'Content-Length': o.data ? Buffer.byteLength(o.data) : 0
+		};
+	}
 
 //AUTHENTICATION
 	/* add authentication to http request */
@@ -125,13 +125,31 @@ function request(options, a, b) {
 
 
 //REQUEST
+	function notImplemented(name) {
+		return function() {
+			console.error('najax: method jqXHR."' + name + '" not implemented');
+			console.trace();
+		};
+	}
+
+	var jqXHR = {
+		readyState: 0,
+		status: 0,
+		statusText: 'error', // one of: "success", "notmodified", "error", "timeout", "abort", or "parsererror"
+		setRequestHeader: notImplemented('setRequestHeader'),
+		getAllResponseHeaders: notImplemented('getAllResponseHeaders'),
+		statusCode: notImplemented('statusCode'),
+		abort: notImplemented('abort')
+	};
+
+
 	var req = (ssl ? https : http).request(options, function(res) {
-			// Allow getting Response Headers from the XMLHTTPRequest object
-			dfd.getResponseHeader = function(header) {
-				return res.headers[header.toLowerCase()];
-			};
+    // Allow getting Response Headers from the XMLHTTPRequest object
+    dfd.getResponseHeader = jqXHR.getResponseHeader = function(header) {
+			return res.headers[header.toLowerCase()];
+    };
 		res.on('data', function(d) {
-			data += d;
+				data += d;
 		});
 		res.on('end', function() {
 			if (o.dataType === 'json') {
@@ -139,15 +157,44 @@ function request(options, a, b) {
 				try { data = JSON.parse(data.replace(/[\cA-\cZ]/gi,'')); }
 				catch(e){ return !o.error||o.error(e); }
 			}
-			if ( _.isFunction(o.success)) { o.success(data); }
-			dfd.resolve(data);
+
+			// Determine if successful
+			var isSuccess = res.statusCode >= 200 && res.statusCode < 300 || res.statusCode === 304;
+			// Set readyState
+			jqXHR.readyState = res.statusCode > 0 ? 4 : 0;
+
+			if (isSuccess) {
+				// Set data for the fake xhr object
+				jqXHR.status = res.statusCode;
+				jqXHR.statusText = 'success';
+
+				if (_.isFunction(o.success)) {
+					o.success(data, 'success', jqXHR);
+				}
+				// success, statusText, jqXHR
+				dfd.resolve(data, 'success', jqXHR);
+			} else {
+				// jqXHR, statusText, error
+				// When an HTTP error occurs, errorThrown receives the textual portion of the
+				// HTTP status, such as "Not Found" or "Internal Server Error."
+				if (_.isFunction(o.error)) {
+					o.error(jqXHR, 'error', http.STATUS_CODES[res.statusCode]);
+				}
+				dfd.reject(jqXHR, 'error', http.STATUS_CODES[res.statusCode]);
+			}
 		});
 	});
-
 //ERROR
 	req.on('error', function(e) {
-		if (_.isFunction(o.error)) { o.error(e); }
-		dfd.reject(e);
+		// Set data for the fake xhr object
+		jqXHR.status = res.statusCode;
+		jqXHR.responseText = e.stack;
+
+		if (_.isFunction(o.error)) {
+			o.error(jqXHR, 'error', e);
+		}
+		// jqXHR, statusText, error
+		dfd.reject(jqXHR, 'error', e);
 	});
 
 //SEND DATA

--- a/lib/najax.js
+++ b/lib/najax.js
@@ -12,7 +12,7 @@ querystring = require('querystring'),
 url         = require('url'),
 $           = require('jquery-deferred'),
 _           = require('underscore'),
-default_settings = { type: 'GET', rejectUnauthorized: true },
+default_settings = { type: 'GET', rejectUnauthorized: true, processData: true },
 najax       = module.exports = request;
 
 
@@ -63,24 +63,28 @@ function request(options, a, b) {
 		data = '';
 
 	//DATA
-		/* massage request data according to options */
-		o.data = o.data || '';
-		o.contentType = o.contentType ? 'application/'+o.contentType :'application/x-www-form-urlencoded';
+	/* massage request data according to options */
+	o.data = o.data || '';
+	o.contentType = o.contentType ? o.contentType : 'application/x-www-form-urlencoded';
 
-		if(!o.encoder){
-			switch(o.contentType){
-				case 'application/json': o.data = JSON.stringify(o.data); break;
-				case 'application/x-www-form-urlencoded': o.data = querystring.stringify(o.data); break;
-				default: o.data = o.data.toString();
-			}
+	// Per jquery docs / source: encoding is only done
+	// if processData is true (defaults to true)
+	// and the data is not already a string
+	// https://github.com/jquery/jquery/blob/master/src/ajax.js#L518
+	if ( o.data && o.processData && typeof o.data !== 'string') {
+		o.data = querystring.stringify(o.data)
+	} else if (typeof o.toString === 'function') {
+		// e.g. handle Node Buffer objects
+		o.data = o.data.toString();
+	}
+
+	if (o.type === 'GET' && o.data) {
+		if (l.search) {
+			l.search += '&' + o.data;
 		} else {
-			o.data = o.encoder(o.data);
+			l.search = '?' + o.data;
 		}
-
-		/* if get, use querystring method for data */
-		if (o.type === 'GET') {
-			l.search = (l.search ? l.search + '&' : ( o.data ? '?'+o.data : '' ));
-		}
+	}
 
 	/* if get, use querystring method for data */
 	options = {


### PR DESCRIPTION
I added a bunch of enhancements to more closely conform to jQuery.ajax's behavior:

- return an error when the status code is not considered to be a success by jQuery's logic (fixes #7)
- call the success and error callbacks with the expected arguments rather than just the data value, 
- return a fake jqXHR object in the success and error callbacks for greater compatibility

Also, if you merge this, could you please do `npm version minor`, `git push`, `git push --tags`  `npm publish`? The version of najax on npm is really old (circa ~ Aug 28, 2012).